### PR TITLE
How about remaining the original destroy method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 SoftDelete
 =============
 
-This module is designed for the [Strongloop Loopback](https://github.com/strongloop/loopback) framework. It allows entities of any Model to be "soft deleted" by adding a `deletedAt` attribute. Queries following the standard format will not return these entities; they can only be accessed by adding `{ deleted: true }` to the query object (at the same level as `where`, `include` etc).
+This module is designed for the [Strongloop Loopback](https://github.com/strongloop/loopback) framework. It allows entities of any Model to be "soft deleted" by adding `deletedAt` (Date) and `deleted` boolean attributes. Queries following the standard format will not return these entities; they can only be accessed by adding `{ deleted: true }` to the query object (at the same level as `where`, `include` etc).
 
-This is a fork from [loopback-softdelete-mixin](https://github.com/studio-mv/loopback-softdelete-mixin) with this pull request applied: [Adds support for MongoDB](https://github.com/studio-mv/loopback-softdelete-mixin/pull/1).
+This is a fork from [loopback-softdelete-mixin4](https://github.com/mendecinisto/loopback-softdelete-mixin), to which the `deleted` boolean property is added to allow for better indexing against non deleted records.
 
 Install
 -------
 
 ```bash
-  npm install --save loopback-softdelete-mixin3
+  npm install --save loopback-softdelete-mixin4
 ```
 
 SERVER CONFIG
@@ -28,7 +28,7 @@ Add the `mixins` property to your `server/model-config.json`:
     ],
     "mixins": [
       "loopback/common/mixins",
-      "../node_modules/loopback-softdelete-mixin3",
+      "../node_modules/loopback-softdelete-mixin4",
       "../common/mixins"
     ]
   }

--- a/README.md
+++ b/README.md
@@ -63,10 +63,21 @@ There are a number of configurable options to the mixin. You can specify an alte
       "scrub": true,
       "index": true
     },
+  ...
+  "list_user_index": {
+      "keys": {
+        "userId": 1,
+        "listId": -1,
+        "deleteIndex": true
+      },
+      "options": {
+        "unique": true 
+      } 
+    }
   },
 ```
 
-If "index" is set to true, an additional property called `deleteIndex` will be configured which will default to 0 and be set to a unix time integer at the time of delete. This is to provide indexing support for the following scenario.
+If "index" is set to true, an additional property called `deleteIndex` will be configured and set to a random string at the time of delete. This is to provide indexing support for the following scenario.
 
 A GroupMembership model which has a `userId` and `groupId` relation to User, and Group models with unique indexing configured to prevent duplicate relations between users and groups. Without the "index" option enabled, soft delete will break this kind of indexing and allow duplicate memberships. 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SoftDelete
 
 This module is designed for the [Strongloop Loopback](https://github.com/strongloop/loopback) framework. It allows entities of any Model to be "soft deleted" by adding `deletedAt` (Date) and `deleted` boolean attributes. Queries following the standard format will not return these entities; they can only be accessed by adding `{ deleted: true }` to the query object (at the same level as `where`, `include` etc).
 
-This is a fork from [loopback-softdelete-mixin4](https://github.com/mendecinisto/loopback-softdelete-mixin), to which the `deleted` boolean property is added to allow for better indexing against non deleted records.
+This is a fork from [loopback-softdelete-mixin4](https://github.com/mendecinisto/loopback-softdelete-mixin), to which the `deletedAt` property type has been changed to 'any' with default value as `false` to allow fopr indexing capability.
 
 Install
 -------

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 SoftDelete
 =============
 
-This module is designed for the [Strongloop Loopback](https://github.com/strongloop/loopback) framework. It allows entities of any Model to be "soft deleted" by adding `deletedAt` (Date) and `deleted` boolean attributes. Queries following the standard format will not return these entities; they can only be accessed by adding `{ deleted: true }` to the query object (at the same level as `where`, `include` etc).
+This module is designed for the [Strongloop Loopback](https://github.com/strongloop/loopback) framework. It allows entities of any Model to be "soft deleted" by adding a `deletedAt` attribute. Queries following the standard format will not return these entities; they can only be accessed by adding `{ deleted: true }` to the query object (at the same level as `where`, `include` etc).
 
-This is a fork from [loopback-softdelete-mixin4](https://github.com/mendecinisto/loopback-softdelete-mixin), to which the `deletedAt` property type has been changed to 'any' with default value as `false` to allow fopr indexing capability.
+This is a fork from [loopback-softdelete-mixin4](https://github.com/mendecinisto/loopback-softdelete-mixin) with added functionality to provide an indexing property option. 
 
 Install
 -------
@@ -54,16 +54,21 @@ To use with your Models add the `mixins` attribute to the definition object of y
   },
 ```
 
-There are a number of configurable options to the mixin. You can specify an alternative property name for `deletedAt`, as well as configuring deletion to "scrub" the entity. If true, this sets all but the "id" fields to null. If an array, it will only scrub properties with those names.
+There are a number of configurable options to the mixin. You can specify an alternative property name for `deletedAt`, as well as configuring deletion to "scrub" the entity. If true, this sets all but the "id" fields to null. If an array, it will only scrub properties with those names. 
 
 ```json
   "mixins": {
     "SoftDelete": {
       "deletedAt": "deleted_at",
       "scrub": true,
+      "indexable": true
     },
   },
 ```
+
+If "indexable" is set to true, an additional property called `deleteIndex` will be configured which will default to 0 and be set to a unix time integer at the time of delete. This is to provide indexing support for the following scenario.
+
+A GroupMembership model which has a `userId` and `groupId` relation to User, and Group models with unique indexing configured to prevent duplicate relations between users and groups. Without the "indexable" otion enabled, soft delete will break this kind of indexing and allow duplicate memberships.
 
 Retrieving deleted entities
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If "index" is set to true, an additional property called `deleteIndex` will be c
 
 A GroupMembership model which has a `userId` and `groupId` relation to User, and Group models with unique indexing configured to prevent duplicate relations between users and groups. Without the "index" option enabled, soft delete will break this kind of indexing and allow duplicate memberships. 
 
-NOTE: Enabling "index" does not create the index. This must be done manually in model.json.
+NOTES: Indexing option has only been tested with the MySQL connector. Enabling "index" does not create the index. This must be done manually in model.json.
 
 Retrieving deleted entities
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -61,14 +61,16 @@ There are a number of configurable options to the mixin. You can specify an alte
     "SoftDelete": {
       "deletedAt": "deleted_at",
       "scrub": true,
-      "indexable": true
+      "index": true
     },
   },
 ```
 
-If "indexable" is set to true, an additional property called `deleteIndex` will be configured which will default to 0 and be set to a unix time integer at the time of delete. This is to provide indexing support for the following scenario.
+If "index" is set to true, an additional property called `deleteIndex` will be configured which will default to 0 and be set to a unix time integer at the time of delete. This is to provide indexing support for the following scenario.
 
-A GroupMembership model which has a `userId` and `groupId` relation to User, and Group models with unique indexing configured to prevent duplicate relations between users and groups. Without the "indexable" otion enabled, soft delete will break this kind of indexing and allow duplicate memberships.
+A GroupMembership model which has a `userId` and `groupId` relation to User, and Group models with unique indexing configured to prevent duplicate relations between users and groups. Without the "index" option enabled, soft delete will break this kind of indexing and allow duplicate memberships. 
+
+NOTE: Enabling "index" does not create the index. This must be done manually in model.json.
 
 Retrieving deleted entities
 ---------------------------

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "loopback-softdelete-mixin3",
+  "name": "loopback-softdelete-mixin4",
   "version": "0.0.12",
-  "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
+  "description": "A mixin to provide soft deletes by adding a deletedAt and deleted attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {
     "preversion": "npm test",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/medicinisto/loopback-softdelete-mixin.git"
+    "url": "https://github.com/joeybenenati/loopback-softdelete-mixin.git"
   },
   "dependencies": {
     "babel-runtime": "^6.3.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-softdelete-mixin4",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-softdelete-mixin4",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-softdelete-mixin4",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-softdelete-mixin4",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-softdelete-mixin4",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-softdelete-mixin4",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-softdelete-mixin4",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {
@@ -20,8 +20,8 @@
     "delete"
   ],
   "author": {
-    "name": "Jouke Visser",
-    "email": "jouke@studio-mv.nl"
+    "name": "Joey Benenati",
+    "email": "joey@wedo.com"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-softdelete-mixin4",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-softdelete-mixin4",
-  "version": "0.0.17",
+  "version": "1.0.0",
   "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-softdelete-mixin4",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-softdelete-mixin4",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-softdelete-mixin4",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loopback-softdelete-mixin4",
-  "version": "0.0.12",
-  "description": "A mixin to provide soft deletes by adding a deletedAt and deleted attribute for loopback Models",
+  "version": "0.0.13",
+  "description": "A mixin to provide soft deletes by adding a deletedAt attribute for loopback Models",
   "main": "src/index.js",
   "scripts": {
     "preversion": "npm test",

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -19,7 +19,7 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false }) => {
     scrubbed = propertiesToScrub.reduce((obj, prop) => ({ ...obj, [prop]: null }), {});
   }
 
-  Model.defineProperty(deletedAt, {type: 'any', required: false, default: false});
+  Model.defineProperty(deletedAt, {type: 'any', required: true, default: false});
 
   Model.destroyAll = function softDestroyAll(where, cb) {
     return Model.updateAll(where, { ...scrubbed, [deletedAt]: new Date()})

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -126,7 +126,7 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false , index = false,
     return _update.call(Model, whereNotDeleted, ...rest);
   };
 
-  if (Model.settings.remoting && Model.settings.remoting.sharedMethods !== false && (deletedById || deleteOp)) {
+  if (Model.settings.remoting && Model.settings.remoting.sharedMethods.deleteById !== false && (deletedById || deleteOp)) {
     Model.disableRemoteMethodByName('deleteById');
 
     Model.remoteMethod('deleteById', {

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -142,7 +142,9 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false , index = false,
     Model.prototype.deleteById = function(options = {}) {
       options.deletedById = options.accessToken ? options.accessToken.userId : null;
       options.deleteOp = 'user';
-      return this.destroy(options);
+      return this.destroy(options).then(function() {
+        return { count: 1 }
+      })
     };
   }
 };

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -140,8 +140,8 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false , index = false,
     });
 
     Model.prototype.deleteById = function(options = {}) {
-      options.deletedById = options.accessToken ? options.accessToken.userId : null;
-      options.deleteOp = 'user';
+      if (deletedById) options.deletedById = options.accessToken ? options.accessToken.userId : null;
+      if (deleteOp && options.deletedById) options.deleteOp = 'user';
       return this.destroy(options).then(function() {
         return { count: 1 }
       })

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -126,7 +126,7 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false , index = false,
     return _update.call(Model, whereNotDeleted, ...rest);
   };
 
-  if (deletedById || deleteOp) {
+  if (Model.settings.remoting.sharedMethods !== false && (deletedById || deleteOp)) {
     Model.disableRemoteMethodByName('deleteById');
 
     Model.remoteMethod('deleteById', {

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -20,9 +20,10 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false }) => {
   }
 
   Model.defineProperty(deletedAt, {type: Date, required: false, default: null});
-
+  Model.defineProperty('deleted', { type: Boolean, required: true, default: false });
+  
   Model.destroyAll = function softDestroyAll(where, cb) {
-    return Model.updateAll(where, { ...scrubbed, [deletedAt]: new Date() })
+    return Model.updateAll(where, { ...scrubbed, [deletedAt]: new Date(), deleted: true  })
       .then(result => (typeof cb === 'function') ? cb(null, result) : result)
       .catch(error => (typeof cb === 'function') ? cb(error) : Promise.reject(error));
   };
@@ -31,7 +32,7 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false }) => {
   Model.deleteAll = Model.destroyAll;
 
   Model.destroyById = function softDestroyById(id, cb) {
-    return Model.updateAll({ [idName]: id }, { ...scrubbed, [deletedAt]: new Date()})
+    return Model.updateAll({ [idName]: id }, { ...scrubbed, [deletedAt]: new Date(), deleted: true })
       .then(result => (typeof cb === 'function') ? cb(null, result) : result)
       .catch(error => (typeof cb === 'function') ? cb(error) : Promise.reject(error));
   };
@@ -42,7 +43,7 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false }) => {
   Model.prototype.destroy = function softDestroy(options, cb) {
     const callback = (cb === undefined && typeof options === 'function') ? options : cb;
 
-    return this.updateAttributes({ ...scrubbed, [deletedAt]: new Date() })
+    return this.updateAttributes({ ...scrubbed, [deletedAt]: new Date(), deleted: true  })
       .then(result => (typeof cb === 'function') ? callback(null, result) : result)
       .catch(error => (typeof cb === 'function') ? callback(error) : Promise.reject(error));
   };

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -140,7 +140,7 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false , index = false,
     });
 
     Model.prototype.deleteById = function(options = {}) {
-      options.deletedById = options.accessToken ? options.accessToken.userId;
+      options.deletedById = options.accessToken ? options.accessToken.userId : null;
       options.deleteOp = 'user';
       return this.destroy(options);
     };

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -61,9 +61,6 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false , index = false,
     if (index) data.deleteIndex = genKey();
     if (deletedById && options.deletedById) data.deletedById = options.deletedById;
     if (deleteOp && options.deleteOp) data.deleteOp = options.deleteOp;
-
-    var deletePromise = index ? this.updateAttributes({ ...scrubbed, [deletedAt]: new Date(), deleteIndex: genKey() }) :
-      this.updateAttributes({ ...scrubbed, [deletedAt]: new Date() }, options);
     
     return this.updateAttributes(data, options)
       .then(result => (typeof cb === 'function') ? callback(null, result) : result)

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -24,8 +24,8 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false , index = false}
 
   Model.destroyAll = function softDestroyAll(where, cb) {
     var deletePromise = index ? Model.updateAll(where, { ...scrubbed, [deletedAt]: new Date(), deleteIndex: new Date().getTime() }) :
-      Model.updateAll(where, { ...scrubbed, [deletedAt]: new Date() });
-
+      Model.updateAll(where, { ...scrubbed, [deletedAt]: new Date() })
+    
     return deletePromise
       .then(result => (typeof cb === 'function') ? cb(null, result) : result)
       .catch(error => (typeof cb === 'function') ? cb(error) : Promise.reject(error));
@@ -35,8 +35,8 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false , index = false}
   Model.deleteAll = Model.destroyAll;
 
   Model.destroyById = function softDestroyById(id, cb) {
-    var deletePromise = index ? Model.updateAll(where, { ...scrubbed, [deletedAt]: new Date(), deleteIndex: new Date().getTime() }) :
-      Model.updateAll(where, { ...scrubbed, [deletedAt]: new Date() });
+    var deletePromise = index ? Model.updateAll({ [idName]: id }, { ...scrubbed, [deletedAt]: new Date(), deleteIndex: new Date().getTime() }) :
+      Model.updateAll({ [idName]: id }, { ...scrubbed, [deletedAt]: new Date() });
 
     return deletePromise
       .then(result => (typeof cb === 'function') ? cb(null, result) : result)
@@ -48,10 +48,9 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false , index = false}
 
   Model.prototype.destroy = function softDestroy(options, cb) {
     const callback = (cb === undefined && typeof options === 'function') ? options : cb;
-
-    var deletePromise = index ? Model.updateAll(where, { ...scrubbed, [deletedAt]: new Date(), deleteIndex: new Date().getTime() }) :
-      Model.updateAll(where, { ...scrubbed, [deletedAt]: new Date() });
-
+    var deletePromise = index ? this.updateAttributes({ ...scrubbed, [deletedAt]: new Date(), deleteIndex: new Date().getTime() }) :
+      this.updateAttributes({ ...scrubbed, [deletedAt]: new Date() });
+    
     return deletePromise
       .then(result => (typeof cb === 'function') ? callback(null, result) : result)
       .catch(error => (typeof cb === 'function') ? callback(error) : Promise.reject(error));

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -126,7 +126,7 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false , index = false,
     return _update.call(Model, whereNotDeleted, ...rest);
   };
 
-  if (Model.settings.remoting.sharedMethods !== false && (deletedById || deleteOp)) {
+  if (Model.settings.remoting && Model.settings.remoting.sharedMethods !== false && (deletedById || deleteOp)) {
     Model.disableRemoteMethodByName('deleteById');
 
     Model.remoteMethod('deleteById', {

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -51,7 +51,7 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false , index = false}
   Model.prototype.destroy = function softDestroy(options, cb) {
     const callback = (cb === undefined && typeof options === 'function') ? options : cb;
     var deletePromise = index ? this.updateAttributes({ ...scrubbed, [deletedAt]: new Date(), deleteIndex: genKey() }) :
-      this.updateAttributes({ ...scrubbed, [deletedAt]: new Date() });
+      this.updateAttributes({ ...scrubbed, [deletedAt]: new Date() }, options);
     
     return deletePromise
       .then(result => (typeof cb === 'function') ? callback(null, result) : result)

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -22,7 +22,7 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false , index = false}
   }
 
   Model.defineProperty(deletedAt, {type: Date, required: false, default: null});
-  if (index) Model.defineProperty('deleteIndex', { type: String, required: true, default: '' });
+  if (index) Model.defineProperty('deleteIndex', { type: String, required: true, default: 'null' });
 
   Model.destroyAll = function softDestroyAll(where, cb) {
     var deletePromise = index ? Model.updateAll(where, { ...scrubbed, [deletedAt]: new Date(), deleteIndex: genKey() }) :

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -19,11 +19,10 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false }) => {
     scrubbed = propertiesToScrub.reduce((obj, prop) => ({ ...obj, [prop]: null }), {});
   }
 
-  Model.defineProperty(deletedAt, {type: Date, required: false, default: null});
-  Model.defineProperty('deleted', { type: Boolean, required: true, default: false });
-  
+  Model.defineProperty(deletedAt, {type: 'any', required: false, default: false});
+
   Model.destroyAll = function softDestroyAll(where, cb) {
-    return Model.updateAll(where, { ...scrubbed, [deletedAt]: new Date(), deleted: true  })
+    return Model.updateAll(where, { ...scrubbed, [deletedAt]: new Date()})
       .then(result => (typeof cb === 'function') ? cb(null, result) : result)
       .catch(error => (typeof cb === 'function') ? cb(error) : Promise.reject(error));
   };
@@ -32,7 +31,7 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false }) => {
   Model.deleteAll = Model.destroyAll;
 
   Model.destroyById = function softDestroyById(id, cb) {
-    return Model.updateAll({ [idName]: id }, { ...scrubbed, [deletedAt]: new Date(), deleted: true })
+    return Model.updateAll({ [idName]: id }, { ...scrubbed, [deletedAt]: new Date() })
       .then(result => (typeof cb === 'function') ? cb(null, result) : result)
       .catch(error => (typeof cb === 'function') ? cb(error) : Promise.reject(error));
   };
@@ -43,7 +42,7 @@ export default (Model, { deletedAt = 'deletedAt', scrub = false }) => {
   Model.prototype.destroy = function softDestroy(options, cb) {
     const callback = (cb === undefined && typeof options === 'function') ? options : cb;
 
-    return this.updateAttributes({ ...scrubbed, [deletedAt]: new Date(), deleted: true  })
+    return this.updateAttributes({ ...scrubbed, [deletedAt]: new Date()})
       .then(result => (typeof cb === 'function') ? callback(null, result) : result)
       .catch(error => (typeof cb === 'function') ? callback(error) : Promise.reject(error));
   };


### PR DESCRIPTION
First of all, I know that this repository is forked from the original one. But I don't know which repository is still maintained, so I wrote this PR in this repository. Acturally, this is not PR, but issue. 

Ok. My idea is, remaining the original destory method with the altered name. (like destoryAllForce, destoryByIdForce). The reason why these method is needed is, in my case, to completely delete test record in the DB. I have some testing codes which create some testing record before test case and delete them all after all test case done. It works fine. But as I test more and more, the deleted records are stacked and it looks ugly.

What's your opinion? It looks like that it only needs few lines of code. Thanks.